### PR TITLE
NotebotStealer fix, new module, port to 1.16.4, build.gradle tweaks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 plugins {
-	id 'fabric-loom' version '0.4-SNAPSHOT'
-	id 'maven-publish'
+    id 'fabric-loom' version '0.5-SNAPSHOT'
+    id 'maven-publish'
 }
 
-allprojects {
-	repositories {
-		maven { url 'https://jitpack.io' }
-	}
+repositories {
+    maven {
+        url 'https://jitpack.io'
+    }
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8
@@ -17,72 +17,60 @@ version = project.mod_version
 group = project.maven_group
 
 dependencies {
-	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+    minecraft "com.mojang:minecraft:${project.minecraft_version}"
+    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
-	modImplementation 'com.github.ZeroMemes:Alpine:1.9'
-	modImplementation 'com.github.Vatuu:discord-rpc:1.6.2'
-	modImplementation 'com.gitlab.CDAGaming:fabritone:fabritone~1.16.x-Fabric-SNAPSHOT'
-	//modImplementation 'org.kitteh.irc:client-lib:7.3.0'
-	//modImplementation 'net.engio:mbassador:1.3.2'
-	include 'com.github.Vatuu:discord-rpc:1.6.2'
-	include 'com.github.ZeroMemes:Alpine:1.9'
-	include 'com.gitlab.CDAGaming:fabritone:fabritone~1.16.x-Fabric-SNAPSHOT'
-	//include 'org.kitteh.irc:client-lib:7.3.0'
-	//include 'net.engio:mbassador:1.3.2'
+    modImplementation 'com.github.ZeroMemes:Alpine:1.9'
+    modImplementation 'com.github.Vatuu:discord-rpc:1.6.2'
+    modImplementation 'com.gitlab.CDAGaming:fabritone:fabritone~1.16.x-Fabric-SNAPSHOT'
+    //modImplementation 'org.kitteh.irc:client-lib:7.3.0'
+    //modImplementation 'net.engio:mbassador:1.3.2'
+    include 'com.github.Vatuu:discord-rpc:1.6.2'
+    include 'com.github.ZeroMemes:Alpine:1.9'
+
+    // TODO: Find way to include fabric~1.16.3-SNAPSHOT cuz this branch is outdated
+    include 'com.gitlab.CDAGaming:fabritone:fabritone~1.16.x-Fabric-SNAPSHOT'
+    //include 'org.kitteh.irc:client-lib:7.3.0'
+    //include 'net.engio:mbassador:1.3.2'
 
 }
 
 processResources {
-	inputs.property "version", project.version
+    inputs.property "version", project.version
 
-	from(sourceSets.main.resources.srcDirs) {
-		include "fabric.mod.json"
-		expand "version": project.version
-	}
+    from(sourceSets.main.resources.srcDirs) {
+        include "fabric.mod.json"
+        expand "version": project.version
+    }
 
-	from(sourceSets.main.resources.srcDirs) {
-		exclude "fabric.mod.json"
-	}
+    from(sourceSets.main.resources.srcDirs) {
+        exclude "fabric.mod.json"
+    }
 }
 
-// ensure that the encoding is set to UTF-8, no matter what the system default is
-// this fixes some edge cases with special characters not displaying correctly
-// see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
 tasks.withType(JavaCompile) {
-	options.encoding = "UTF-8"
+    options.encoding = "UTF-8"
 }
 
-// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-// if it is present.
-// If you remove this task, sources will not be generated.
 task sourcesJar(type: Jar, dependsOn: classes) {
-	classifier = "sources"
-	from sourceSets.main.allSource
+    classifier = "sources"
+    from sourceSets.main.allSource
 }
 
 jar {
-	from "LICENSE"
+    from "LICENSE"
 }
 
-// configure the maven publication
 publishing {
-	publications {
-		mavenJava(MavenPublication) {
-			// add all the jars that should be included when publishing to maven
-			artifact(remapJar) {
-				builtBy remapJar
-			}
-			artifact(sourcesJar) {
-				builtBy remapSourcesJar
-			}
-		}
-	}
-
-	// select the repositories you want to publish to
-	repositories {
-		// uncomment to publish to the local maven
-		// mavenLocal()
-	}
+    publications {
+        mavenJava(MavenPublication) {
+            artifact(remapJar) {
+                builtBy remapJar
+            }
+            artifact(sourcesJar) {
+                builtBy remapSourcesJar
+            }
+        }
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx3G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/use
-	minecraft_version=1.16.3
-	yarn_mappings=1.16.3+build.7
-	loader_version=0.9.3+build.207
+	minecraft_version=1.16.4
+    yarn_mappings=1.16.4+build.7
+	loader_version=0.10.8
 
 # Mod Properties
 	mod_version = 2500
@@ -14,4 +14,4 @@ org.gradle.jvmargs=-Xmx3G
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	#fabric_version=0.13.1+build.370-1.16
+	#fabric_version=0.28.4+1.16

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx3G
 # Fabric Properties
 	# check these on https://fabricmc.net/use
 	minecraft_version=1.16.4
-    yarn_mappings=1.16.4+build.7
+	yarn_mappings=1.16.4+build.7
 	loader_version=0.10.8
 
 # Mod Properties

--- a/src/main/java/bleach/hack/command/CommandManager.java
+++ b/src/main/java/bleach/hack/command/CommandManager.java
@@ -53,7 +53,8 @@ public class CommandManager {
             new CmdSetting(),
             new CmdSkull(),
             new CmdToggle(),
-            new CmdXray()
+            new CmdXray(),
+            new CmdItemList()
     );
 
     public static List<Command> getCommands() {

--- a/src/main/java/bleach/hack/command/commands/CmdItemList.java
+++ b/src/main/java/bleach/hack/command/commands/CmdItemList.java
@@ -1,0 +1,42 @@
+package bleach.hack.command.commands;
+
+import bleach.hack.command.Command;
+import bleach.hack.utils.BleachLogger;
+import bleach.hack.utils.file.BleachFileMang;
+import net.minecraft.item.Item;
+import net.minecraft.util.registry.Registry;
+
+public class CmdItemList extends Command {
+
+    @Override
+    public String getAlias() {
+        return "itemlist";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Makes a txt file with all item IDs";
+    }
+
+    @Override
+    public String getSyntax() {
+        return "itemlist";
+    }
+
+    @Override
+    public void onCommand(String command, String[] args) {
+        BleachFileMang.createFile("itemlist.txt");
+        boolean first = true;
+        StringBuilder builder = new StringBuilder();
+        for (Item item : Registry.ITEM) {
+            if (!first) {
+                builder.append(",");
+                first = false;
+            }
+            builder.append(Registry.ITEM.getId(item).getPath());
+            builder.append('\n');
+        }
+        BleachFileMang.appendFile(builder.toString(), "itemlist.txt");
+        BleachLogger.infoMessage("Saved item list as: itemlist.txt");
+    }
+}

--- a/src/main/java/bleach/hack/command/commands/CmdRbook.java
+++ b/src/main/java/bleach/hack/command/commands/CmdRbook.java
@@ -70,7 +70,7 @@ public class CmdRbook extends Command {
         for (int t = 0; t < pages; t++) textSplit.add(StringTag.of(text.substring(t * pageChars, (t + 1) * pageChars)));
 
         item.getOrCreateTag().put("pages", textSplit);
-        mc.player.networkHandler.sendPacket(new BookUpdateC2SPacket(item, false, Hand.MAIN_HAND));
+        mc.player.networkHandler.sendPacket(new BookUpdateC2SPacket(item, false, Hand.MAIN_HAND.ordinal()));
     }
 
 }

--- a/src/main/java/bleach/hack/module/mods/BookCrash.java
+++ b/src/main/java/bleach/hack/module/mods/BookCrash.java
@@ -30,7 +30,7 @@ import net.minecraft.item.Items;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.StringTag;
-import net.minecraft.network.packet.c2s.play.ClickWindowC2SPacket;
+import net.minecraft.network.packet.c2s.play.ClickSlotC2SPacket;
 import net.minecraft.network.packet.c2s.play.CreativeInventoryActionC2SPacket;
 import net.minecraft.network.packet.c2s.play.UpdateSignC2SPacket;
 import net.minecraft.network.packet.s2c.play.DisconnectS2CPacket;
@@ -106,7 +106,7 @@ public class BookCrash extends Module {
 
             for (int i = 0; i < getSetting(1).asSlider().getValue(); i++) {
                 if (getSetting(0).asMode().mode == 0) {
-                    mc.player.networkHandler.sendPacket(new ClickWindowC2SPacket(0, 0, 0, SlotActionType.PICKUP, bookObj, (short) 0));
+                    mc.player.networkHandler.sendPacket(new ClickSlotC2SPacket(0, 0, 0, SlotActionType.PICKUP, bookObj, (short) 0));
                 } else {
                     mc.player.networkHandler.sendPacket(new CreativeInventoryActionC2SPacket(0, bookObj));
                 }

--- a/src/main/java/bleach/hack/module/mods/NoSlow.java
+++ b/src/main/java/bleach/hack/module/mods/NoSlow.java
@@ -30,7 +30,7 @@ import net.minecraft.client.gui.screen.ChatScreen;
 import net.minecraft.client.options.KeyBinding;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.entity.effect.StatusEffects;
-import net.minecraft.network.packet.c2s.play.ClickWindowC2SPacket;
+import net.minecraft.network.packet.c2s.play.ClickSlotC2SPacket;
 import net.minecraft.network.packet.c2s.play.ClientCommandC2SPacket;
 import net.minecraft.network.packet.c2s.play.ClientCommandC2SPacket.Mode;
 import net.minecraft.util.math.BlockPos;
@@ -157,7 +157,7 @@ public class NoSlow extends Module {
 
     @Subscribe
     public void onSendPacket(EventSendPacket event) {
-        if (event.getPacket() instanceof ClickWindowC2SPacket && getSetting(6).asToggle().asToggle().getChild(1).asToggle().state) {
+        if (event.getPacket() instanceof ClickSlotC2SPacket && getSetting(6).asToggle().asToggle().getChild(1).asToggle().state) {
             mc.player.networkHandler.sendPacket(new ClientCommandC2SPacket(mc.player, Mode.STOP_SPRINTING));
         }
     }

--- a/src/main/java/bleach/hack/module/mods/NotebotStealer.java
+++ b/src/main/java/bleach/hack/module/mods/NotebotStealer.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map.Entry;
+import java.io.File;
 
 public class NotebotStealer extends Module {
 
@@ -58,8 +59,17 @@ public class NotebotStealer extends Module {
         int i = 0;
         String s = "";
 
-        while (BleachFileMang.fileExists("notebot", "notebot" + i + ".txt")) i++;
-        for (List<Integer> i1 : notes) s += i1.get(0) + ":" + i1.get(1) + ":" + i1.get(2) + "\n";
+        // TODO: Figure out how to use BleachFileMang instead
+        File theDir = new File("./bleach/notebot");
+        if (!theDir.exists()) {
+            theDir.mkdirs();
+        }
+
+        while (BleachFileMang.fileExists("notebot", "notebot" + i + ".txt"))
+            i++;
+        for (List<Integer> i1 : notes)
+            s += i1.get(0) + ":" + i1.get(1) + ":" + i1.get(2) + "\n";
+        BleachFileMang.createFile("notebot", "notebot" + i + ".txt");
         BleachFileMang.appendFile(s, "notebot", "notebot" + i + ".txt");
         BleachLogger.infoMessage("Saved Song As: notebot" + i + ".txt [" + notes.size() + " Notes]");
     }


### PR DESCRIPTION
Ported the project to newest version of Fabric 1.16.4

Fixed NotebotStealer because it wasn't creating any txt files at all

I added new module in a form of command. It generates list of all item IDs. It is good for devs.
Usage: ,itemlist and it makes new file called itemlist.txt

Removed some comments and useless code in build.gradle